### PR TITLE
fix injection query

### DIFF
--- a/src/content/posts/mdx-syntax-highlight-treesitter-nvim/index.mdx
+++ b/src/content/posts/mdx-syntax-highlight-treesitter-nvim/index.mdx
@@ -160,7 +160,9 @@ parser's name, in our case it's `tsx`:
 
 ```scheme title="~/.config/nvim/after/queries/markdown/injections.scm"
 ; extends
-((inline) @_inline (#match? @_inline "^\(import\|export\)")) @tsx
+(((inline) @_inline) @injection.content
+  (#match? @_inline "^\(import\|export\)")
+  (#set! injection.language "tsx"))
 ```
 
 <ReactCompareSlider client:load>


### PR DESCRIPTION
injection query syntax was changed in nvim 0.9